### PR TITLE
always exclude org.kde.plasmashell

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -4,6 +4,7 @@
 const alwaysExcludedApplications = [
     "krunner",
     "org.kde.yakuake",
+    "org.kde.plasmashell"
 ];
 
 /// User specified applications to exclude from being centered.


### PR DESCRIPTION
Fixes https://github.com/Merrit/kwin-center-new-windows/issues/2

I have not observed any adverse affects in my limited testing. 